### PR TITLE
Argparse return code

### DIFF
--- a/src/pyJiraCli/__main__.py
+++ b/src/pyJiraCli/__main__.py
@@ -67,18 +67,6 @@ _CMD_MODULS = [
 # Classes
 ################################################################################
 
-
-class ArgumentParser(argparse.ArgumentParser):
-    """ Overridden ArgumentParser class to raise an exception on error.
-        This is needed to handle the return values of the program without exiting.
-    """
-
-    def error(self, message):
-        self.print_usage(sys.stderr)
-        if message:
-            print(f"Error: {message}")
-        raise RuntimeError(message)
-
 ################################################################################
 # Functions
 ################################################################################
@@ -95,12 +83,12 @@ def add_parser() -> object:
     Returns:
         obj:  The parser object for commandline arguments.
     """
-    parser = ArgumentParser(prog='pyJiraCli',
-                            description="A CLI tool to import and export Jira issues \
+    parser = argparse.ArgumentParser(prog='pyJiraCli',
+                                     description="A CLI tool to import and export Jira issues \
                                                   between server and JSON or CSV files.",
-                            epilog="Copyright (c) 2024 NewTec GmbH - " +
-                            __license__ +
-                            " - Find the project on GitHub: " + __repository__)
+                                     epilog="Copyright (c) 2024 NewTec GmbH - " +
+                                     __license__ +
+                                     " - Find the project on GitHub: " + __repository__)
 
     parser.add_argument('--user', '-u',
                         type=str,
@@ -155,27 +143,25 @@ def main() -> Ret:
     # Get parser
     parser = add_parser()
 
-    try:
-        args = parser.parse_args(input_arguments)
-        assert args is not None
-        assert args.func is not None
-    except RuntimeError:
-        ret_status = Ret.RET_ERROR_PARSE_ARGUMENTS
-    else:
-        # In verbose mode print all program arguments
-        if args.verbose:
-            printer.set_verbose()
-            print("Program arguments: ")
+    args = parser.parse_args(input_arguments)
 
-            for arg in vars(args):
-                print(f"* {arg} = {vars(args)[arg]}")
-            print("\n")
+    assert args is not None
+    assert args.func is not None
 
-        # call command function and return exit status
-        ret_status = args.func(args)
+    # In verbose mode print all program arguments
+    if args.verbose:
+        printer.set_verbose()
+        print("Program arguments: ")
 
-        if ret_status != Ret.RET_OK:
-            printer.print_error(PrintType.ERROR, ret_status)
+        for arg in vars(args):
+            print(f"* {arg} = {vars(args)[arg]}")
+        print("\n")
+
+    # call command function and return exit status
+    ret_status = args.func(args)
+
+    if ret_status != Ret.RET_OK:
+        printer.print_error(PrintType.ERROR, ret_status)
 
     return ret_status
 

--- a/src/pyJiraCli/printer.py
+++ b/src/pyJiraCli/printer.py
@@ -57,7 +57,7 @@ TYPE = {
 RETURN_MSG = {
     Ret.RET_OK                           : "Process succesful",
     Ret.RET_ERROR                        : "Error occured",
-    Ret.RET_ERROR_JIRA_LOGIN             : "Login to jira server was not possible",
+    Ret.RET_ERROR_ARGPARSE               : "Error while parsing arguments",
     Ret.RET_ERROR_FILEPATH_INVALID       : "The provided -path doesnt exist",
     Ret.RET_ERROR_WORNG_FILE_FORMAT      : "Wrong file format for save file provided",
     Ret.RET_ERROR_ISSUE_NOT_FOUND        : "Jira Issue not found",
@@ -77,6 +77,7 @@ RETURN_MSG = {
                                            "option with the login command",
     Ret.RET_ERROR_CREATING_TICKET_FAILED : "creating the ticket on the jira server failed",
     Ret.RET_ERROR_INVALID_SEARCH         : "search string returned a jira error",
+    Ret.RET_ERROR_JIRA_LOGIN             : "Login to jira server was not possible",
 }
 
 WARN_MSG = {

--- a/src/pyJiraCli/ret.py
+++ b/src/pyJiraCli/ret.py
@@ -44,7 +44,7 @@ class Ret(IntEnum):
     """ The exit statuses of the modules."""
     RET_OK                           = 0
     RET_ERROR                        = 1
-    RET_ERROR_JIRA_LOGIN             = 2
+    RET_ERROR_ARGPARSE               = 2 # Must be 2 to match the argparse error code.
     RET_ERROR_FILEPATH_INVALID       = 3
     RET_ERROR_WORNG_FILE_FORMAT      = 4
     RET_ERROR_ISSUE_NOT_FOUND        = 5
@@ -56,7 +56,7 @@ class Ret(IntEnum):
     RET_ERROR_MISSING_DATATYPE       = 11
     RET_ERROR_CREATING_TICKET_FAILED = 12
     RET_ERROR_INVALID_SEARCH         = 13
-    RET_ERROR_PARSE_ARGUMENTS        = 14
+    RET_ERROR_JIRA_LOGIN             = 14
 
 class Warnings(IntEnum):
     """ Th Warnings of the modules."""

--- a/src/pyJiraCli/ret.py
+++ b/src/pyJiraCli/ret.py
@@ -56,6 +56,7 @@ class Ret(IntEnum):
     RET_ERROR_MISSING_DATATYPE       = 11
     RET_ERROR_CREATING_TICKET_FAILED = 12
     RET_ERROR_INVALID_SEARCH         = 13
+    RET_ERROR_PARSE_ARGUMENTS        = 14
 
 class Warnings(IntEnum):
     """ Th Warnings of the modules."""


### PR DESCRIPTION
Return code of argparse is ignored and does not exit of missing required argument.
Fix to show usage message in Python 3.8 when no argument is passed to the executable.
Cleaned main file.